### PR TITLE
Fix version range for ocramius/package-versions PHP <7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.0",
-        "ocramius/package-versions": "^1.2.0"
+        "ocramius/package-versions": "1.2 - 1.5.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
ocramius/package-versions has bumped their minimum version requirement to PHP 7.4. Subsequently, this causes `composer update` to fail on any environments that do not have PHP 7.4. Given that this package has a minimum requirement of PHP 7 and it is in use by thousands of other libraries such as Sentry, it seems fair to restrict the version range for the offending package here and not there it self.