### PR TITLE
Use proper 7.0+ dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.0",
-        "ocramius/package-versions": "^1.2.0"
+        "composer/package-versions-deprecated": "^1.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"


### PR DESCRIPTION
Many tools are currently blocked from updating/using to composer v2 due to your package using the Ocramius package, which already now is 7.4+.
Many of us are software vendors that need to keep libraries 7.2 compatible, and that cannot be done using this package right now.
The composer guys offered a way to do that using this package until everyone is safely beyond 7.4+. 
But given the policy of how this library is run, I would advice to keep using the composer version here even beyond that (the problem wont go away).

See also https://github.com/Ocramius/PackageVersions/pull/133 to why this is necessary.