### PR TITLE
Throw specific exception when version cannot be retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes of the `jean85/pretty-package-versions` package are documented in this file using the 
 [Keep a CHANGELOG](http://keepachangelog.com/) principles.
 
+## [2.0.1] - 2021-01-28
+This small patch handles replaced and provided packages, so that consumers of this library can handle bad requests gracefully.
+
+### Added
+ * Add `VersionMissingExceptionInterface`, and two exceptions implementing it: `ProvidedPackageException` and `ReplacedPackageException` 
+### Fixed
+ * Throw explicit `ProvidedPackageException` when asking for the version of a package which is provided (was `\TypeError` before)
+ * Throw explicit `ReplacedPackageException` when asking for the version of a package which is replaced (was `\TypeError` before)
+
 ## [2.0.0] - 2021-01-14
 This release is aimed to become a bridge for native Composer 2 support. The BC breaks are minimal; if you're using it in a library, you're encouraged to require it  with `^1.5 || ^2.0`, so that your end users will not be constrained to use a specific Composer version. 
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.17",
+        "jean85/composer-provided-replaced-stub-package": "^1.0",
         "phpstan/phpstan": "^0.12.66",
         "phpunit/phpunit": "^7.5|^8.5|^9.4",
         "vimeo/psalm": "^4.3"

--- a/src/Exception/ProvidedPackageException.php
+++ b/src/Exception/ProvidedPackageException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jean85\Exception;
+
+class ProvidedPackageException extends \Exception implements VersionMissingExceptionInterface
+{
+    public static function create(string $packageName): VersionMissingExceptionInterface
+    {
+        return new self('Cannot retrieve a version for package ' . $packageName . ' since it is provided, probably a metapackage');
+    }
+}

--- a/src/Exception/ReplacedPackageException.php
+++ b/src/Exception/ReplacedPackageException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jean85\Exception;
+
+class ReplacedPackageException extends \Exception implements VersionMissingExceptionInterface
+{
+    public static function create(string $packageName): VersionMissingExceptionInterface
+    {
+        return new self('Cannot retrieve a version for package ' . $packageName . ' since it is replaced by some other package');
+    }
+}

--- a/src/Exception/VersionMissingExceptionInterface.php
+++ b/src/Exception/VersionMissingExceptionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jean85\Exception;
+
+interface VersionMissingExceptionInterface extends \Throwable
+{
+    public static function create(string $packageName): self;
+}

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -5,11 +5,20 @@ declare(strict_types=1);
 namespace Jean85;
 
 use Composer\InstalledVersions;
+use Jean85\Exception\ProvidedPackageException;
+use Jean85\Exception\VersionMissingExceptionInterface;
 
 class PrettyVersions
 {
+    /**
+     * @throws VersionMissingExceptionInterface
+     */
     public static function getVersion(string $packageName): Version
     {
+        if (isset(InstalledVersions::getRawData()['versions'][$packageName]['provided'])) {
+            throw ProvidedPackageException::create($packageName);
+        }
+
         return new Version(
             $packageName,
             InstalledVersions::getPrettyVersion($packageName),

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -12,7 +12,7 @@ use Jean85\Exception\VersionMissingExceptionInterface;
 class PrettyVersions
 {
     /**
-     * @throws VersionMissingExceptionInterface
+     * @throws VersionMissingExceptionInterface When a package is provided ({@see ProvidedPackageException}) or replaced ({@see ReplacedPackageException})
      */
     public static function getVersion(string $packageName): Version
     {

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -6,6 +6,7 @@ namespace Jean85;
 
 use Composer\InstalledVersions;
 use Jean85\Exception\ProvidedPackageException;
+use Jean85\Exception\ReplacedPackageException;
 use Jean85\Exception\VersionMissingExceptionInterface;
 
 class PrettyVersions
@@ -17,6 +18,10 @@ class PrettyVersions
     {
         if (isset(InstalledVersions::getRawData()['versions'][$packageName]['provided'])) {
             throw ProvidedPackageException::create($packageName);
+        }
+
+        if (isset(InstalledVersions::getRawData()['versions'][$packageName]['replaced'])) {
+            throw ReplacedPackageException::create($packageName);
         }
 
         return new Version(

--- a/tests/Unit/PrettyVersionsTest.php
+++ b/tests/Unit/PrettyVersionsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use Jean85\PrettyVersions;
+use PHPUnit\Framework\TestCase;
+
+class PrettyVersionsTest extends TestCase
+{
+    public function testGetVersionOfReplacedPackage(): void
+    {
+        $this->expectException(\Throwable::class);
+
+        PrettyVersions::getVersion('monolog/monolog');
+    }
+
+    public function testGetVersionOfProvidedPackage(): void
+    {
+        $this->expectException(\Throwable::class);
+
+        PrettyVersions::getVersion('psr/log-implementation');
+    }
+}

--- a/tests/Unit/PrettyVersionsTest.php
+++ b/tests/Unit/PrettyVersionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit;
 
+use Jean85\Exception\ProvidedPackageException;
 use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 
@@ -18,7 +19,8 @@ class PrettyVersionsTest extends TestCase
 
     public function testGetVersionOfProvidedPackage(): void
     {
-        $this->expectException(\Throwable::class);
+        $this->expectException(ProvidedPackageException::class);
+        $this->expectExceptionMessage('Cannot retrieve a version for package psr/log-implementation since it is provided, probably a metapackage');
 
         PrettyVersions::getVersion('psr/log-implementation');
     }

--- a/tests/Unit/PrettyVersionsTest.php
+++ b/tests/Unit/PrettyVersionsTest.php
@@ -26,4 +26,11 @@ class PrettyVersionsTest extends TestCase
 
         PrettyVersions::getVersion('psr/log-implementation');
     }
+
+    public function testGetVersionOfMissingPackage(): void
+    {
+        $this->expectException(\OutOfBoundsException::class);
+
+        PrettyVersions::getVersion('foo/bar');
+    }
 }

--- a/tests/Unit/PrettyVersionsTest.php
+++ b/tests/Unit/PrettyVersionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit;
 
 use Jean85\Exception\ProvidedPackageException;
+use Jean85\Exception\ReplacedPackageException;
 use Jean85\PrettyVersions;
 use PHPUnit\Framework\TestCase;
 
@@ -12,7 +13,8 @@ class PrettyVersionsTest extends TestCase
 {
     public function testGetVersionOfReplacedPackage(): void
     {
-        $this->expectException(\Throwable::class);
+        $this->expectException(ReplacedPackageException::class);
+        $this->expectExceptionMessage('Cannot retrieve a version for package monolog/monolog since it is replaced by some other package');
 
         PrettyVersions::getVersion('monolog/monolog');
     }


### PR DESCRIPTION
This is a way to solve the same stuff that I tried to solve in #16, but for 2.0.

Basically, if we ask for the version of a replaced or provided package, we get an exception, as seen in https://github.com/getsentry/sentry-php/pull/1170, specifically in https://github.com/getsentry/sentry-php/pull/1170/checks?check_run_id=1782914100#step:9:33

Trying to cram some data in there would be a disservice to the end user, because it could go unnoticed. As explained thoroughly by Jordi himself in https://github.com/Jean85/pretty-package-versions/pull/16#issuecomment-620550459:
> Getting a version is just not always a valid use case. It'll work if the package is installed normally, but really people should rather rely on satisfies if they want to know whether a given version number is present.
So I prefer to:
 * avoid giving the user incomplete or wrong data
 * throw a specific exception for each case
 * add the `VersionMissingExceptionInterface` to all of them to allow the end user to catch them all at once
