### PR TITLE
NO_REFERENCE_TEXT in  Version::NO_REFERENCE_TEXT

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -20,7 +20,7 @@ class Version
     /** @var bool */
     private $versionIsTagged;
 
-    const NO_REFERENCE_TEXT = '{no reference}';
+    public const NO_REFERENCE_TEXT = '{no reference}';
 
     public function __construct(string $packageName, string $prettyVersion, ?string $reference = null)
     {

--- a/src/Version.php
+++ b/src/Version.php
@@ -20,11 +20,13 @@ class Version
     /** @var bool */
     private $versionIsTagged;
 
+    const NO_REFERENCE_TEXT = '{no reference}';
+
     public function __construct(string $packageName, string $prettyVersion, ?string $reference = null)
     {
         $this->packageName = $packageName;
         $this->prettyVersion = $prettyVersion;
-        $this->reference = $reference ?? '{no reference}';
+        $this->reference = $reference ?? self::NO_REFERENCE_TEXT;
         $this->versionIsTagged = preg_match('/[^v\d\.]/', $this->getShortVersion()) === 0;
     }
 

--- a/src/Version.php
+++ b/src/Version.php
@@ -27,7 +27,7 @@ class Version
         $this->packageName = $packageName;
         $this->prettyVersion = $prettyVersion;
         $this->reference = $reference ?? self::NO_REFERENCE_TEXT;
-        $this->versionIsTagged = preg_match('/[^v\d\.]/', $this->getShortVersion()) === 0;
+        $this->versionIsTagged = preg_match('/[^v\d.]/', $this->getShortVersion()) === 0;
     }
 
     public function getPrettyVersion(): string


### PR DESCRIPTION
Text ``` '{no reference}' ``` is strange, and  {  }  make usage of output from this function not usable in many scopes (for example url with hash). 

Especially strange is when is is parsed by getShortReference()  =>  ``` {no ref ``` 

My suggest is change this behavior in future releases. But for now - this should help fix it in user scope. 
