### PR TITLE
Deprecate InstalledVersions::getRawData

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,12 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
+      # PHP8.0 will use the latest composer version
+      - run: composer self-update
+        if: matrix.php == '8.0'
+      # All other version will be locked to an outdated composer version
+      - run: composer self-update --rollback 2.0.13
+        if: matrix.php != '8.0'
       - run: composer install --no-progress --ansi
         if: matrix.php != '8.0'
       - run: composer install --no-progress --ansi --ignore-platform-reqs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,37 +17,28 @@ jobs:
           - '7.3'
           - '7.4'
           - '8.0'
+        composer_version: ['v2']
+        include:
+          - description: '(prefer lowest)'
+            php: '7.1'
+            composer_version: '2.0.0'
+            dependencies: 'lowest'
 
-    name: PHP ${{ matrix.php }} tests
+    name: PHP ${{ matrix.php }} tests ${{ matrix.description }}
     steps:
       # checkout git
       - uses: actions/checkout@v2
-      # cache
-      - uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: ${{ matrix.php }}
       # setup PHP
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:${{ matrix.composer_version }}
           coverage: xdebug
-      # PHP8.0 will use the latest composer version
-      - run: composer self-update --no-progress --ansi
-        if: matrix.php == '8.0'
-      # All other version will be locked to an outdated composer version
-      - run: curl --silent --show-error https://getcomposer.org/installer -o composer-setup.php && php composer-setup.php --version=2.0.13 && mv composer.phar /usr/bin/composer && chmod -x /usr/bin/composer
-        if: matrix.php != '8.0'
-      - run: composer install --no-progress --ansi
-        if: matrix.php != '8.0'
-      - run: composer install --no-progress --ansi --ignore-platform-reqs
-        if: matrix.php == '8.0'
+      - uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: ${{ matrix.dependencies }}
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml
-        if: matrix.php != '8.0'
-      - run: vendor/bin/phpunit
-        if: matrix.php == '8.0'
       - uses: codecov/codecov-action@v1
-        if: matrix.php != '8.0'
         with:
           file: './coverage.xml'
           fail_ci_if_error: true
@@ -56,41 +47,29 @@ jobs:
     name: Code style
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: '7.4'
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           coverage: none
-      - run: composer install --no-progress --ansi
+      - uses: "ramsey/composer-install@v1"
       - run: vendor/bin/php-cs-fixer fix --ansi --verbose --dry-run
   PHPStan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: '7.4'
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           coverage: none
-      - run: composer install --no-progress --ansi
+      - uses: "ramsey/composer-install@v1"
       - run: vendor/bin/phpstan analyse
   Psalm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: '7.4'
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
           coverage: none
-      - run: composer install --no-progress --ansi
+      - uses: "ramsey/composer-install@v1"
       - run: vendor/bin/psalm

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,10 +33,10 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
       # PHP8.0 will use the latest composer version
-      - run: composer self-update
+      - run: composer self-update --no-progress --ansi
         if: matrix.php == '8.0'
       # All other version will be locked to an outdated composer version
-      - run: composer self-update --rollback 2.0.13
+      - run: composer self-update --rollback 2.0.13 --no-progress --ansi
         if: matrix.php != '8.0'
       - run: composer install --no-progress --ansi
         if: matrix.php != '8.0'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,7 @@ jobs:
       - run: composer self-update --no-progress --ansi
         if: matrix.php == '8.0'
       # All other version will be locked to an outdated composer version
-      - run: composer self-update --rollback 2.0.13 --no-progress --ansi
+      - run: curl --silent --show-error https://getcomposer.org/installer -o composer-setup.php && php composer-setup.php --version=2.0.13 && mv composer.phar /usr/bin/composer && chmod -x /usr/bin/composer
         if: matrix.php != '8.0'
       - run: composer install --no-progress --ansi
         if: matrix.php != '8.0'

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -16,13 +16,9 @@ class PrettyVersions
      */
     public static function getVersion(string $packageName): Version
     {
-        if (isset(InstalledVersions::getRawData()['versions'][$packageName]['provided'])) {
-            throw ProvidedPackageException::create($packageName);
-        }
+        self::checkProvidedPackages($packageName);
 
-        if (isset(InstalledVersions::getRawData()['versions'][$packageName]['replaced'])) {
-            throw ReplacedPackageException::create($packageName);
-        }
+        self::checkReplacedPackages($packageName);
 
         return new Version(
             $packageName,
@@ -43,5 +39,23 @@ class PrettyVersions
             InstalledVersions::getRootPackage()['pretty_version'],
             InstalledVersions::getRootPackage()['reference']
         );
+    }
+
+    protected static function checkProvidedPackages(string $packageName): void
+    {
+        foreach (InstalledVersions::getAllRawData() as $installed) {
+            if (isset($installed['versions'][$packageName]['provided'])) {
+                throw ProvidedPackageException::create($packageName);
+            }
+        }
+    }
+
+    protected static function checkReplacedPackages(string $packageName): void
+    {
+        foreach (InstalledVersions::getAllRawData() as $installed) {
+            if (isset($installed['versions'][$packageName]['replaced'])) {
+                throw ReplacedPackageException::create($packageName);
+            }
+        }
     }
 }

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -43,6 +43,12 @@ class PrettyVersions
 
     protected static function checkProvidedPackages(string $packageName): void
     {
+        if (! method_exists(InstalledVersions::class, 'getAllRawData')) {
+            if (isset(InstalledVersions::getRawData()['versions'][$packageName]['provided'])) {
+                throw ProvidedPackageException::create($packageName);
+            }
+        }
+
         foreach (InstalledVersions::getAllRawData() as $installed) {
             if (isset($installed['versions'][$packageName]['provided'])) {
                 throw ProvidedPackageException::create($packageName);
@@ -52,6 +58,12 @@ class PrettyVersions
 
     protected static function checkReplacedPackages(string $packageName): void
     {
+        if (! method_exists(InstalledVersions::class, 'getAllRawData')) {
+            if (isset(InstalledVersions::getRawData()['versions'][$packageName]['replaced'])) {
+                throw ReplacedPackageException::create($packageName);
+            }
+        }
+
         foreach (InstalledVersions::getAllRawData() as $installed) {
             if (isset($installed['versions'][$packageName]['replaced'])) {
                 throw ReplacedPackageException::create($packageName);

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -47,6 +47,8 @@ class PrettyVersions
             if (isset(InstalledVersions::getRawData()['versions'][$packageName]['provided'])) {
                 throw ProvidedPackageException::create($packageName);
             }
+
+            return;
         }
 
         foreach (InstalledVersions::getAllRawData() as $installed) {
@@ -62,6 +64,8 @@ class PrettyVersions
             if (isset(InstalledVersions::getRawData()['versions'][$packageName]['replaced'])) {
                 throw ReplacedPackageException::create($packageName);
             }
+
+            return;
         }
 
         foreach (InstalledVersions::getAllRawData() as $installed) {


### PR DESCRIPTION
Composer released an [update](https://getcomposer.org/changelog/2.0.14) that deprecates the `getRawData()` method.

This PR uses the new recommended `getAllRawData()` method.

This package is used by https://github.com/getsentry/sentry-php. After a recent deployment, Sentry stopped working because of the change made by composer. I hope to get this PR merged and then update the requirement in Sentry.

Related commit in Composer: https://github.com/composer/composer/pull/9816/files

