### PR TITLE
Bump Composer API to 2.1+

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,19 +14,17 @@ jobs:
     strategy:
       matrix:
         php:
-          - '7.1'
-          - '7.2'
-          - '7.3'
           - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         composer_version: ['v2']
         include:
           - description: '(prefer lowest)'
-            php: '7.1'
-            composer_version: '2.0.0'
+            php: '7.4'
+            composer_version: '2.1.0'
             dependencies: 'lowest'
 
     name: PHP ${{ matrix.php }} tests ${{ matrix.description }}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A library to get pretty versions strings of installed dependencies",
     "type": "library",
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.4|^8.0",
         "composer-runtime-api": "^2.1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": "^7.1|^8.0",
-        "composer-runtime-api": "^2.0.0"
+        "composer-runtime-api": "^2.1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2",

--- a/src/PrettyVersions.php
+++ b/src/PrettyVersions.php
@@ -43,14 +43,6 @@ class PrettyVersions
 
     protected static function checkProvidedPackages(string $packageName): void
     {
-        if (! method_exists(InstalledVersions::class, 'getAllRawData')) {
-            if (isset(InstalledVersions::getRawData()['versions'][$packageName]['provided'])) {
-                throw ProvidedPackageException::create($packageName);
-            }
-
-            return;
-        }
-
         foreach (InstalledVersions::getAllRawData() as $installed) {
             if (isset($installed['versions'][$packageName]['provided'])) {
                 throw ProvidedPackageException::create($packageName);
@@ -60,14 +52,6 @@ class PrettyVersions
 
     protected static function checkReplacedPackages(string $packageName): void
     {
-        if (! method_exists(InstalledVersions::class, 'getAllRawData')) {
-            if (isset(InstalledVersions::getRawData()['versions'][$packageName]['replaced'])) {
-                throw ReplacedPackageException::create($packageName);
-            }
-
-            return;
-        }
-
         foreach (InstalledVersions::getAllRawData() as $installed) {
             if (isset($installed['versions'][$packageName]['replaced'])) {
                 throw ReplacedPackageException::create($packageName);


### PR DESCRIPTION
#53 highlighted that we can drop a check on the presence of `\Composer\InstalledVersions::getAllRawData`. That's there since Composer APIs 2.1+ (see https://github.com/composer/composer/commit/f5e6cc89cd8d45c99cff77ee80d0f324ada45686).

So we can do a round of bumps and release them as 2.1.0:
 * PHP version (7.4+, add tests for 8.4)
 * Composer API
 * remove deprecations from CS fixer