### PR TITLE
Add PHP 8.5 to tests workflow

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,6 +20,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
         composer_version: ['v2']
         include:
           - description: '(prefer lowest)'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,9 +41,7 @@ jobs:
       - uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: ${{ matrix.dependencies }}
-      # only until psalm 6 support is added for PHP 8.5
-      - run: composer remove --dev vimeo/psalm --no-update
-        if: matrix.php == '8.5'
+      - run: composer remove --dev vimeo/psalm friendsofphp/php-cs-fixer --no-update
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -41,6 +41,9 @@ jobs:
       - uses: "ramsey/composer-install@v3"
         with:
           dependency-versions: ${{ matrix.dependencies }}
+      # only until psalm 6 support is added for PHP 8.5
+      - run: composer remove --dev vimeo/psalm --no-update
+        if: matrix.php == '8.5'
       - run: vendor/bin/phpunit --coverage-clover=coverage.xml
       - uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
Add PHP version 8.5 to the workflow configuration.

Psalm 6.x-dev is needed and there are 6 errors.

I guess a PR for Psalm 6 support should be added first.